### PR TITLE
Fixed npm package name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A HTTP(S) temperature and humidity accessory for [Homebridge](https://github.com
 # Installation
 
 1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin using: `npm install -g homebridge-http-temperature-humidity`
+2. Install this plugin using: `npm install -g homebridge-httptemperaturehumidity`
 3. Update your configuration file. See `sample-config.json` in this repository for a sample.
 
 # Configuration


### PR DESCRIPTION
I installed this package using the README instructions and npm installed the code from https://github.com/vknabel/homebridge-http-temperature-humidity repository and not this one :) 
I only realised this after not getting the negative temperatures to show up at all.